### PR TITLE
Refactor and bug fixes for Minesweeper game

### DIFF
--- a/games/minesweeper/app.js
+++ b/games/minesweeper/app.js
@@ -166,6 +166,9 @@ $(() => {
             ) {
             if ($square.hasClass("flag")) {
                 $square.text("")
+                if ($square.hasClass("bomb")) {
+                    matches--
+                }
                 flags--
             } else {
                 $square.text("🚩")


### PR DESCRIPTION
Cleans up:
- Long, confusing functions
- Weird variable names
- Comments that said the same thing as the variable name

Fixes:
- Bug that allows player to win by right-clicking a bomb spot 40 times

Adds: 
- Win condition if player leaves only the bomb squares unchecked (they can only do this by clicking on safe spots)